### PR TITLE
Add janet hypertext

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Please read this document before making contributions.
 * `my.package.git`
 * `org.this.is.not.java.AbstractWidgetFactoryProducer`
 
-If you would like to add a package here, just open a pull request with the name and URL of the package and edit the packages.janet file.
+If you would like to add a package here, just open a pull request with the name and URL of the package and edit the pkgs.janet file.
 
 ## Broken Links
 

--- a/pkgs.janet
+++ b/pkgs.janet
@@ -32,4 +32,5 @@
    'temple "https://git.sr.ht/~bakpakin/temple"
    'tahani "https://github.com/pepe/tahani.git"
    'jtbox "https://github.com/sepisoad/jtbox.git"
+   'hypertext "https://gitlab.com/louis.jackman/janet-hypertext"
   })

--- a/pkgs.janet
+++ b/pkgs.janet
@@ -32,5 +32,5 @@
    'temple "https://git.sr.ht/~bakpakin/temple"
    'tahani "https://github.com/pepe/tahani.git"
    'jtbox "https://github.com/sepisoad/jtbox.git"
-   'hypertext "https://gitlab.com/louis.jackman/janet-hypertext"
+   'hypertext "https://gitlab.com/louis.jackman/janet-hypertext.git"
   })


### PR DESCRIPTION
Not sure what the criteria is for submitting a new package apart from following CONTRIBUTING; thought I'd try my luck. It installs fine via `jpm` remotely, at least for me.