### PR TITLE
Add Jermbox

### DIFF
--- a/pkgs.janet
+++ b/pkgs.janet
@@ -14,6 +14,7 @@
    'hypertext "https://gitlab.com/louis.jackman/janet-hypertext.git"
    'jaylib "https://github.com/janet-lang/jaylib.git"
    'jdn-loader "https://github.com/levitanong/jdn-loader.git"
+   'jermbox "https://github.com/MorganPeterson/jermbox.git"
    'jhydro "https://github.com/janet-lang/jhydro.git"
    'joy "https://github.com/joy-framework/joy.git"
    'jpm "https://github.com/janet-lang/jpm.git"


### PR DESCRIPTION
Jermbox
https://github.com/MorganPeterson/jermbox

Jermbox is a native module that allows using [Termbox Next](https://github.com/nullgemm/termbox_next) as a framework for making a TUI.

There is already an existing library,  [jtbox](https://github.com/sepisoad/jtbox), that does this but it uses a long abandoned version of [Termbox](https://github.com/nsf/termbox). Plus, it does not include all possible bindings to the API.

My version uses a different version of Termbox and includes binding to the whole of the API and makes for a good alternative to Sepisoad's package.