### PR TITLE
add args module

### DIFF
--- a/pkgs.janet
+++ b/pkgs.janet
@@ -1,6 +1,7 @@
 # A curated list of packages
 (def packages
   {'argparse "https://github.com/janet-lang/argparse.git"
+   'args "https://github.com/MorganPeterson/args.git"
    'base16 "https://github.com/andrewchambers/janet-base16.git"
    'bigint "https://github.com/andrewchambers/janet-big.git"
    'bearimy "https://git.sr.ht/~pepe/bearimy"


### PR DESCRIPTION
Args
https://github.com/MorganPeterson/args

Args is a simple (KISS) command line argument parser. It is made for flags only. Meaning that it won't take arguments like `-x xvariable`. It will only do flags like `-x` or `--letterx`. It will also handle multiple flags at once, `-xyz`.

I know there is an argparse module, but I think this makes a good light version for those who need it. 