### PR TITLE
Add janet-msgpack

### DIFF
--- a/pkgs.janet
+++ b/pkgs.janet
@@ -35,6 +35,7 @@
    'mendoza "https://github.com/bakpakin/mendoza.git"
    'michael "https://git.sr.ht/~pepe/michael"
    'miniz "https://github.com/bakpakin/janet-miniz.git"
+   'msgpack "https://github.com/Techcable/janet-msgpack.git"
    'nanoid "https://git.sr.ht/~statianzo/janet-nanoid"
    'path "https://github.com/janet-lang/path.git"
    'pkgs "https://github.com/janet-lang/pkgs.git"


### PR DESCRIPTION
Hi! I wrote a [msgpack](https://msgpack.org) implemetation over at [Techcable/janet-msgpack](https://github.com/Techcable/janet-msgpack).

It's basically binary-coded json (and as a result smaller and faster).

Right now it supports decoding and encoding all the basic datatypes (array, map, int, float) and clocks in at about 68k on my laptop.

The only features lacking are:
1. support for [extension types](https://github.com/msgpack/msgpack/blob/master/spec.md#extension-types)
2. a couple customization options for decoding of string types.

It turns out I did not need this for my project, but it works very well in my tests. Please open an issue if you have a problem (or a PR if you want a new feature)

😄 