### PR TITLE
Removed glyph as the project was retired

### DIFF
--- a/pkgs.janet
+++ b/pkgs.janet
@@ -17,7 +17,6 @@
    'fugue "https://git.sr.ht/~subsetpark/fugue"
    'gapbuffer "https://github.com/MorganPeterson/gapbuffer.git"
    'glfw "https://gitlab.com/jeannekamikaze/janet-glfw.git"
-   'glyph "https://tasadar.net/tionis/glyph.janet.git"
    'hemple "https://git.sr.ht/~pepe/hemple"
    'html "https://github.com/swlkr/janet-html.git"
    'hypertext "https://gitlab.com/louis.jackman/janet-hypertext.git"


### PR DESCRIPTION
Glyph was rewritten in bash and is thus no longer a janet package