### PR TITLE
Add openbsd package

### DIFF
--- a/pkgs.janet
+++ b/pkgs.janet
@@ -40,6 +40,7 @@
    'miniz "https://github.com/bakpakin/janet-miniz.git"
    'msgpack "https://github.com/Techcable/janet-msgpack.git"
    'nanoid "https://git.sr.ht/~statianzo/janet-nanoid"
+   'openbsd "https://git.sr.ht/~les/janet-openbsd"
    'openssl-hash "https://github.com/wooosh/janet-openssl-hash"
    'pkgs "https://github.com/janet-lang/pkgs.git"
    'pq "https://github.com/andrewchambers/janet-pq.git"


### PR DESCRIPTION
After asking a lot of questions on our Zulip instance (thanks to everyone who helped me figure things out!), I would like to contribute something that I - and hopefully others - can benefit from.

janet-openbsd ([GitHub](https://github.com/lescx/janet-openbsd) [sourcehut](https://git.sr.ht/~les/janet-openbsd)) is a wrapper around the OpenBSD specific syscalls. 

Currently, the two most prominent and important syscalls [`pledge(2)`](https://man.openbsd.org/pledge.2) and [`unveil(2)`](https://man.openbsd.org/unveil.2) are implemented. Both syscalls are used for compile-time sandboxing.

Needless to say, this package is only useful for OpenBSD people.

TODOs for the future:

* Implement other syscalls.
* Learn about testing with Janet and implement a proper testing framework for this package.

Thank you for being such a warm and friendly community.