### PR TITLE
Add base64

### DIFF
--- a/pkgs.janet
+++ b/pkgs.janet
@@ -3,6 +3,7 @@
   {'argparse "https://github.com/janet-lang/argparse.git"
    'args "https://github.com/MorganPeterson/args.git"
    'base16 "https://github.com/andrewchambers/janet-base16.git"
+   'base64 "https://github.com/Jakski/janet-base64.git"
    'bigint "https://github.com/andrewchambers/janet-big.git"
    'bearimy "https://git.sr.ht/~pepe/bearimy"
    'bonzer "https://git.sr.ht/~pepe/bonzer"


### PR DESCRIPTION
This is a pure Janet implementation of Base64. It's been added since there has been an interest https://github.com/janet-lang/spork/pull/185

Let me know if you believe that this package should be called differently.