### PR TITLE
Add kanja, a miniKanren implementation for Janet

### DIFF
--- a/pkgs.janet
+++ b/pkgs.janet
@@ -34,6 +34,7 @@
    'jurl "https://github.com/cosmictoast/jurl.git"
    'juv "https://github.com/janet-lang/juv.git"
    'kamilah "https://git.sr.ht/~pepe/kamilah"
+   'kanja "https://github.com/arkh-node/janet-kanja.git"
    'manisha "https://git.sr.ht/~pepe/manisha"
    'marble "https://git.sr.ht/~pepe/marble"
    'mendoza "https://github.com/bakpakin/mendoza.git"


### PR DESCRIPTION
Adds `kanja`, an implementation of miniKanren for Janet.

**What it is.** Relational programming embedded in Janet: pure relations with
complete interleaving search, deferred constraints (`=/=`, `symbolo`,
`numbero`, `absento`), and a search that can be put down and resumed with a
step budget. The core follows µKanren (Hemann & Friedman, 2013), the surface
follows miniKanren as presented in *The Reasoned Schemer*.

**Why add it.** miniKanren has been ported to more than forty languages, and
the list Will Byrd keeps at minikanren.org does not include Janet. This fills
that gap. It is pure Janet: no C, no FFI, no system calls, no dependencies.

**Checked against the requirements in CONTRIBUTING:**

* `jpm install https://github.com/arkh-node/janet-kanja.git` works; installed
  as `kanja`, imports and answers. Verified on a clean tree, not assumed.
* `project.janet` in the root with `:name`, `:author`, `:description`,
  `:license`, `:url`, `:repo`, `:dependencies`.
* `LICENSE` in the root (MIT, as are the canonical implementations).
* README with overview, usage, installation and a section of caveats.
* Test suite: 179 checks, `./run-tests.sh`, the verdict is the exit code.

**On the tests, since the registry values them.** The expected answers are not
taken from what this engine prints. They are taken from faster-minikanren run
under Guile side by side, query for query: printed form of constraints, answer
order, holes, occurs check, all four kinds of demand, 38 queries, matching term
for term. The suite is also checked by mutation, breaking the engine in one
place at a time and requiring the battery to go red; it currently catches 16
breakages out of 16.

**Disclosure, per the Janet CONTRIBUTING policy on LLMs and tool usage.** This
library was written by Aleksei Rybnikov together with ArkH, a synthetic mind.
No generated code is embedded in the Janet runtime; this is an external package
in pure Janet. The divergences we know about are written down in the README
rather than left to be found: the answer order differs from the canon on one
shape (completeness intact, localised, not yet explained), and `(quote x)` is
printed as `'x` where the canon prints it in full.