### PR TITLE
Add capnp (HaoZeke/capnp-janet)

### DIFF
--- a/pkgs.janet
+++ b/pkgs.janet
@@ -7,6 +7,7 @@
    'bigint "https://github.com/andrewchambers/janet-big.git"
    'bearimy "https://git.sr.ht/~pepe/bearimy"
    'bonzer "https://git.sr.ht/~pepe/bonzer"
+   'capnp "https://github.com/HaoZeke/capnp-janet.git"
    'chidi "https://git.sr.ht/~pepe/chidi"
    'circlet "https://github.com/janet-lang/circlet.git"
    'cmd "https://github.com/ianthehenry/cmd.git"


### PR DESCRIPTION
Native Cap'n Proto serialization runtime for Janet, plus a C library embedders can link without the Janet VM.

- Repo: https://github.com/HaoZeke/capnp-janet
- Docs: https://capnp-janet.rgoswami.me/
- `project.janet` declares the native module as `capnp` (`:name`, `:author`, `:description`, `:license`, `:url`, `:repo`).
- Install: `jpm install https://github.com/HaoZeke/capnp-janet.git` (or `jpm install capnp` after this lists).
- MIT license, README, tests, `capnpc-janet` plugin.

`(import capnp)` is the public Janet surface.